### PR TITLE
fix!: some situations may cause maximum call stack size exceeded

### DIFF
--- a/demo/demo.main.ts
+++ b/demo/demo.main.ts
@@ -14,13 +14,9 @@ export const returnVoidExecutor = () => worker.execute("returnVoid");
 
 export const returnNullExecutor = () => worker.execute("returnNull");
 
-const offset1 = new OffscreenCanvas(0, 0);
-export const receiveAndReturnOffscreenCanvas1Executor = () =>
-  worker.execute("receiveAndReturnOffscreenCanvas1", [offset1], offset1);
-
-const offset2 = new OffscreenCanvas(0, 0);
-export const receiveAndReturnOffscreenCanvas2Executor = () =>
-  worker.execute("receiveAndReturnOffscreenCanvas2", [offset2], offset2);
+const offscreen = new OffscreenCanvas(0, 0);
+export const receiveAndReturnOffscreenCanvasExecutor = () =>
+  worker.execute("receiveAndReturnOffscreenCanvas", [offscreen], offscreen);
 
 export const returnUncloneableDataExecutor = () =>
   worker.execute("returnUncloneableData");

--- a/demo/demo.worker.ts
+++ b/demo/demo.worker.ts
@@ -13,11 +13,7 @@ export type DemoActions = {
 
   returnNull: () => ActionResult<null>;
 
-  receiveAndReturnOffscreenCanvas1: (
-    offscreen: OffscreenCanvas
-  ) => ActionResult<OffscreenCanvas>;
-
-  receiveAndReturnOffscreenCanvas2: (
+  receiveAndReturnOffscreenCanvas: (
     offscreen: OffscreenCanvas
   ) => ActionResult<OffscreenCanvas>;
 
@@ -78,12 +74,8 @@ onmessage = createOnmessage<DemoActions>({
     return null;
   },
 
-  async receiveAndReturnOffscreenCanvas1(offscreen) {
+  async receiveAndReturnOffscreenCanvas(offscreen) {
     this.$end(offscreen, [offscreen]);
-  },
-
-  async receiveAndReturnOffscreenCanvas2(offscreen) {
-    return offscreen;
   },
 
   async returnUncloneableData() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -906,14 +906,14 @@ export class WorkerHandler<A extends CommonActions> {
       | null,
     ...payloads: Parameters<A[K]>
   ) {
-    let inputedTransfer: ExecuteOptions["transfer"] = "auto";
+    let inputedTransfer: ExecuteOptions["transfer"] = [];
     let timeout: number = 0;
     if (Array.isArray(options) || options === "auto") {
       inputedTransfer = options;
     } else if (typeof options === "number") {
       timeout = options;
     } else if (typeof options === "object" && options !== null) {
-      inputedTransfer = options.transfer || "auto";
+      inputedTransfer = options.transfer || [];
       timeout = options.timeout || 0;
     }
     const transfer =

--- a/src/main.ts
+++ b/src/main.ts
@@ -666,7 +666,9 @@ export class WorkerHandler<A extends CommonActions> {
     const _this = this;
 
     const handler: ProxyHandler<any> = {
-      get(_target, property, receiver) {
+      get(_target, property) {
+        if (typeof property === "symbol") return;
+
         if (
           (target === Symbol.for("root_proxy") ||
             target === Symbol.for("sub_proxy")) &&
@@ -682,8 +684,6 @@ export class WorkerHandler<A extends CommonActions> {
             return value;
           }
         }
-
-        if (typeof property === "symbol") return receiver[property];
 
         let propertyValue: keyof any | (keyof any)[];
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -228,7 +228,7 @@ function postProxyData(
     ? parentProxyTargetTreeNode.value.transfer.filter((item) =>
         judgeContainer(data, item)
       )
-    : getTransfers(data);
+    : [];
   try {
     if (!judgeStructuredCloneable(proxyDataMsg))
       throw new Error("could not be cloned.");
@@ -329,7 +329,7 @@ export function createOnmessage<A extends CommonActions>(
       // // postMsgWithId 就是 action 中的 this.$post()
       const postMsgWithId: PostMsgWithId = (
         data?: any,
-        transfer: Transferable[] | "auto" = "auto"
+        transfer: Transferable[] | "auto" = []
       ) => {
         postActionMessage(
           {
@@ -345,7 +345,7 @@ export function createOnmessage<A extends CommonActions>(
       // postResultWithId 就是 action 中的 this.$end()
       const postResultWithId: PostMsgWithId = (
         data?: any,
-        transfer: Transferable[] | "auto" = "auto"
+        transfer: Transferable[] | "auto" = []
       ) => {
         postActionMessage(
           {
@@ -380,16 +380,12 @@ export function createOnmessage<A extends CommonActions>(
           payloadList
         );
         if (data !== undefined) {
-          const transfer = getTransfers(data);
-          postActionMessage(
-            {
-              data,
-              executionId,
-              done: true,
-              type: "action_data",
-            },
-            transfer
-          );
+          postActionMessage({
+            data,
+            executionId,
+            done: true,
+            type: "action_data",
+          });
         }
       } catch (error: any) {
         if (

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -4,8 +4,7 @@ import worker, {
   pingLaterExecutor,
   returnVoidExecutor,
   returnNullExecutor,
-  receiveAndReturnOffscreenCanvas1Executor,
-  receiveAndReturnOffscreenCanvas2Executor,
+  receiveAndReturnOffscreenCanvasExecutor,
   returnUncloneableDataExecutor,
   returnUncloneableDataWithOffscreenCanvasExecutor,
   receiveProxyDataExecutor,
@@ -94,37 +93,18 @@ describe("actions", function () {
     });
   });
 
-  describe("receiveAndReturnOffscreenCanvas1", function () {
+  describe("receiveAndReturnOffscreenCanvas", function () {
     let receiveAndReturnOffscreenCanvas1Port: ReturnType<
-      typeof receiveAndReturnOffscreenCanvas1Executor
+      typeof receiveAndReturnOffscreenCanvasExecutor
     >;
 
     it("event", function () {
       receiveAndReturnOffscreenCanvas1Port =
-        receiveAndReturnOffscreenCanvas1Executor();
+        receiveAndReturnOffscreenCanvasExecutor();
     });
 
     it("promise", async function () {
       const { data } = await receiveAndReturnOffscreenCanvas1Port.promise;
-      expect(data instanceof OffscreenCanvas).to.equal(true);
-
-      const typeCheck: IsEqual<typeof data, OffscreenCanvas> = true;
-      expect(typeCheck).to.equal(true);
-    });
-  });
-
-  describe("receiveAndReturnOffscreenCanvas2", function () {
-    let receiveAndReturnOffscreenCanvas2Port: ReturnType<
-      typeof receiveAndReturnOffscreenCanvas2Executor
-    >;
-
-    it("event", function () {
-      receiveAndReturnOffscreenCanvas2Port =
-        receiveAndReturnOffscreenCanvas2Executor();
-    });
-
-    it("promise", async function () {
-      const { data } = await receiveAndReturnOffscreenCanvas2Port.promise;
       expect(data instanceof OffscreenCanvas).to.equal(true);
 
       const typeCheck: IsEqual<typeof data, OffscreenCanvas> = true;


### PR DESCRIPTION
fix: #1 

BREAKING CHANGE: when passing data, if the `transfer` option is not
specified, or when using the return value of an `Action` to respond
with data, the default behavior is to not transfer anything rather than
automatically identifying and transferring the `transferable objects`.